### PR TITLE
Download certificates from Let's Encrypt website

### DIFF
--- a/letsencrypt-expiration.sh
+++ b/letsencrypt-expiration.sh
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $(lsb_release -sc) = "jessie" || $(lsb_release -sc) = "stretch" ]]; then
   apt-get install ca-certificates -y
   sed -i -e 's|mozilla/DST_Root_CA_X3.crt|#mozilla/DST_Root_CA_X3.crt|g' /etc/ca-certificates.conf
   sed -i -e 's|mozilla/ISRG_Root_X1.crt|#mozilla/ISRG_Root_X1.crt|g' /etc/ca-certificates.conf
-  wget https://raw.githubusercontent.com/xenetis/letsencrypt-expiration/main/certificates/isrgrootx1.crt -P /usr/local/share/ca-certificates/
-  wget https://raw.githubusercontent.com/xenetis/letsencrypt-expiration/main/certificates/lets-encrypt-r3.crt -P /usr/local/share/ca-certificates/
+  wget https://letsencrypt.org/certs/lets-encrypt-r3.pem -P /usr/local/share/ca-certificates/
+  wget https://letsencrypt.org/certs/isrgrootx1.pem -P /usr/local/share/ca-certificates/
   update-ca-certificates -f
 fi
 if [[ $(lsb_release -sc) = "buster" ]]; then
+  apt-get update --allow-releaseinfo-change -y
   apt-get install ca-certificates -y
 fi


### PR DESCRIPTION
This PR resolves #2 and #3.
The scripts now downloads the certificates from Let's Encrypt directly.

Also added the `--allow-releaseinfo-change` when it's buster.
